### PR TITLE
RTC: nuvoton: Add nuvoton real time clock driver

### DIFF
--- a/drivers/rtc/rtc-nct3018y.c
+++ b/drivers/rtc/rtc-nct3018y.c
@@ -50,13 +50,15 @@ struct nct3018y {
 #endif
 };
 
+static struct rtc_time intrusion_timestamp;
+
 static int nct3018y_set_alarm_mode(struct i2c_client *client, bool on)
 {
 	int err, flags;
 
 	dev_dbg(&client->dev, "%s:on:%d\n", __func__, on);
 
-	flags =  i2c_smbus_read_byte_data(client, NCT3018Y_REG_CTRL);
+	flags = i2c_smbus_read_byte_data(client, NCT3018Y_REG_CTRL);
 	if (flags < 0) {
 		dev_dbg(&client->dev,
 			"Failed to read NCT3018Y_REG_CTRL\n");
@@ -68,7 +70,7 @@ static int nct3018y_set_alarm_mode(struct i2c_client *client, bool on)
 	else
 		flags &= ~NCT3018Y_BIT_AIE;
 
-	flags |= NCT3018Y_BIT_CIE;
+	//flags |= NCT3018Y_BIT_CIE;
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_CTRL, flags);
 	if (err < 0) {
 		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_CTRL\n");
@@ -119,6 +121,41 @@ static int nct3018y_get_alarm_mode(struct i2c_client *client, unsigned char *ala
 	return 0;
 }
 
+static int nct3018y_set_intrusion_mode(struct i2c_client *client, bool on)
+{
+	int err, flags;
+
+	dev_dbg(&client->dev, "%s:on:%d\n", __func__, on);
+
+	flags = i2c_smbus_read_byte_data(client, NCT3018Y_REG_INTR_CTRL);
+	if (flags < 0) {
+		dev_dbg(&client->dev,
+			"Failed to read NCT3018Y_REG_INTR_CTRL\n");
+		return flags;
+	}
+
+	/* Clear intrusion flag first. */
+	flags &= ~NCT3018Y_BIT_INTRF; /* This bit can be cleared only when INTRUDER# is high */
+	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_INTR_CTRL, flags);
+	if (err < 0) {
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_INTR_CTRL\n");
+		return err;
+	}
+
+	if (on)
+		flags |= NCT3018Y_BIT_INTRIE;
+	else
+		flags &= ~NCT3018Y_BIT_INTRIE;
+
+	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_INTR_CTRL, flags);
+	if (err < 0) {
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_INTR_CTRL\n");
+		return err;
+	}
+
+	return 0;
+}
+
 static int nct3018y_get_intrusion_timestamp(struct i2c_client *client, struct rtc_time *tm)
 {
 	int ret = 0;
@@ -131,7 +168,6 @@ static int nct3018y_get_intrusion_timestamp(struct i2c_client *client, struct rt
 	tm->tm_sec = bcd2bin(buf[0] & 0x7F);
 	tm->tm_min = bcd2bin(buf[1] & 0x7F);
 	tm->tm_hour = bcd2bin(buf[2] & 0xFF);
-	tm->tm_wday = bcd2bin(buf[3] & 0x3F);
 	tm->tm_mday = bcd2bin(buf[3] & 0x3F);
 	tm->tm_mon = bcd2bin(buf[4] & 0x1F) - 1;
 	tm->tm_year = bcd2bin(buf[5]) + 100;
@@ -139,7 +175,7 @@ static int nct3018y_get_intrusion_timestamp(struct i2c_client *client, struct rt
 	dev_dbg(&client->dev, "%s:s=%d m=%d, hr=%d\n",
 		__func__, tm->tm_sec, tm->tm_min,
 		tm->tm_hour);
-	return rtc_valid_tm(tm);
+	return 0;
 }
 
 static int nct3018y_get_intrusion_mode(struct i2c_client *client, unsigned char *enable,
@@ -205,8 +241,19 @@ static ssize_t intrusion_store(struct device *dev,
 
 static DEVICE_ATTR_RW(intrusion);
 
+static ssize_t intrusion_timestamp_show(struct device *dev,
+			       struct device_attribute *attr, char *buf)
+{
+	struct rtc_time *intrusion_ts = &intrusion_timestamp;
+
+	return sprintf(buf, "%ptR UTC\n", intrusion_ts);
+};
+
+static DEVICE_ATTR_RO(intrusion_timestamp);
+
 static struct attribute *nct3018y_attrs[] = {
 	&dev_attr_intrusion.attr,
+	&dev_attr_intrusion_timestamp.attr,
 	NULL
 };
 
@@ -214,12 +261,11 @@ static const struct attribute_group nct3018y_attr_group = {
 	.attrs	= nct3018y_attrs,
 };
 
-
 static irqreturn_t nct3018y_irq(int irq, void *dev_id)
 {
 	struct nct3018y *nct3018y = i2c_get_clientdata(dev_id);
 	struct i2c_client *client = nct3018y->client;
-	struct rtc_time intrusion_timestamp;
+	struct rtc_time *intrusion_ts = &intrusion_timestamp;
 	int err;
 	unsigned char alarm_flag;
 	unsigned char alarm_enable;
@@ -239,14 +285,15 @@ static irqreturn_t nct3018y_irq(int irq, void *dev_id)
 	}
 
 	err = nct3018y_get_intrusion_mode(nct3018y->client, &intrusion_enable, &intrusion_flag);
-	if (err)
+	if (err < 0)
 		return IRQ_NONE;
 
 	if (intrusion_enable && intrusion_flag) {
 		/* Get the timestamp of intrusion event */
-		err = nct3018y_get_intrusion_timestamp(nct3018y->client, &intrusion_timestamp);
+		err = nct3018y_get_intrusion_timestamp(nct3018y->client, intrusion_ts);
 		if (err < 0)
 			return IRQ_NONE;
+		nct3018y_set_intrusion_mode(nct3018y->client, 0);
 	}
 
 	return IRQ_HANDLED;
@@ -569,6 +616,7 @@ static int nct3018y_probe(struct i2c_client *client,
 {
 	struct nct3018y *nct3018y;
 	int err, flags;
+	u32 intrusion_en;
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C |
 				     I2C_FUNC_SMBUS_BYTE |
@@ -592,7 +640,7 @@ static int nct3018y_probe(struct i2c_client *client,
 		dev_dbg(&client->dev, "%s: NCT3018Y_BIT_TWO is set\n", __func__);
 	}
 
-	flags = NCT3018Y_BIT_TWO;
+	flags = NCT3018Y_BIT_TWO | NCT3018Y_BIT_HF;
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_CTRL, flags);
 	if (err < 0) {
 		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_CTRL\n");
@@ -628,6 +676,11 @@ static int nct3018y_probe(struct i2c_client *client,
 	err = rtc_add_group(nct3018y->rtc, &nct3018y_attr_group);
 	if (err)
 		return err;
+
+	/* Enable intrusion interrupt */
+	of_property_read_u32(client->dev.of_node, "intrusion-enable", &intrusion_en);
+	dev_dbg(&client->dev, "%s(%d) intrusion_en=%d\n", __func__, __LINE__, intrusion_en);
+	nct3018y_set_intrusion_mode(nct3018y->client, intrusion_en);
 
 #ifdef CONFIG_COMMON_CLK
 	/* register clk in common clk framework */

--- a/drivers/rtc/rtc-nct3018y.c
+++ b/drivers/rtc/rtc-nct3018y.c
@@ -42,7 +42,7 @@ struct nct3018y {
 	struct rtc_device *rtc;
 	struct i2c_client *client;
 #ifdef CONFIG_COMMON_CLK
-	struct clk_hw		clkout_hw;
+	struct clk_hw clkout_hw;
 #endif
 };
 
@@ -54,7 +54,7 @@ static int nct3018y_set_alarm_mode(struct i2c_client *client, bool on)
 
 	flags =  i2c_smbus_read_byte_data(client, NCT3018Y_REG_CTRL);
 	if (flags < 0) {
-		dev_err(&client->dev,
+		dev_dbg(&client->dev,
 			"Failed to read NCT3018Y_REG_CTRL\n");
 		return flags;
 	}
@@ -67,13 +67,13 @@ static int nct3018y_set_alarm_mode(struct i2c_client *client, bool on)
 	flags |= NCT3018Y_BIT_CIE;
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_CTRL, flags);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_CTRL\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_CTRL\n");
 		return err;
 	}
 
 	flags =  i2c_smbus_read_byte_data(client, NCT3018Y_REG_ST);
 	if (flags < 0) {
-		dev_err(&client->dev,
+		dev_dbg(&client->dev,
 			"Failed to read NCT3018Y_REG_ST\n");
 		return flags;
 	}
@@ -81,7 +81,7 @@ static int nct3018y_set_alarm_mode(struct i2c_client *client, bool on)
 	flags &= ~(NCT3018Y_BIT_AF);
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_ST, flags);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_ST\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_ST\n");
 		return err;
 	}
 
@@ -89,9 +89,9 @@ static int nct3018y_set_alarm_mode(struct i2c_client *client, bool on)
 }
 
 static int nct3018y_get_alarm_mode(struct i2c_client *client, unsigned char *alarm_enable,
-				  unsigned char *alarm_flag)
+				   unsigned char *alarm_flag)
 {
-	int err, flags;
+	int flags;
 
 	if (alarm_enable) {
 		dev_dbg(&client->dev, "%s:NCT3018Y_REG_CTRL\n", __func__);
@@ -150,6 +150,15 @@ static int nct3018y_rtc_read_time(struct device *dev, struct rtc_time *tm)
 	unsigned char buf[10];
 	int err;
 
+	err = i2c_smbus_read_i2c_block_data(client, NCT3018Y_REG_ST, 1, buf);
+	if (err < 0)
+		return err;
+
+	if (!buf[0]) {
+		dev_dbg(&client->dev, " voltage <=1.7, date/time is not reliable.\n");
+		return -EINVAL;
+	}
+
 	err = i2c_smbus_read_i2c_block_data(client, NCT3018Y_REG_SC, sizeof(buf), buf);
 	if (err < 0)
 		return err;
@@ -174,32 +183,32 @@ static int nct3018y_rtc_set_time(struct device *dev, struct rtc_time *tm)
 	buf[0] = bin2bcd(tm->tm_sec);
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_SC, buf[0]);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_SC\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_SC\n");
 		return err;
 	}
 
 	buf[0] = bin2bcd(tm->tm_min);
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_MN, buf[0]);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_MN\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_MN\n");
 		return err;
 	}
 
 	buf[0] = bin2bcd(tm->tm_hour);
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_HR, buf[0]);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_HR\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_HR\n");
 		return err;
 	}
 
 	buf[0] = tm->tm_wday & 0x07;
 	buf[1] = bin2bcd(tm->tm_mday);
-	buf[2] = bin2bcd(tm->tm_mon+1);
+	buf[2] = bin2bcd(tm->tm_mon + 1);
 	buf[3] = bin2bcd(tm->tm_year - 100);
 	err = i2c_smbus_write_i2c_block_data(client, NCT3018Y_REG_DW,
 					     sizeof(buf), buf);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write for day and mon and year\n");
+		dev_dbg(&client->dev, "Unable to write for day and mon and year\n");
 		return -EIO;
 	}
 
@@ -215,7 +224,7 @@ static int nct3018y_rtc_read_alarm(struct device *dev, struct rtc_wkalrm *tm)
 	err = i2c_smbus_read_i2c_block_data(client, NCT3018Y_REG_SCA,
 					    sizeof(buf), buf);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to read date\n");
+		dev_dbg(&client->dev, "Unable to read date\n");
 		return -EIO;
 	}
 
@@ -240,32 +249,27 @@ static int nct3018y_rtc_read_alarm(struct device *dev, struct rtc_wkalrm *tm)
 static int nct3018y_rtc_set_alarm(struct device *dev, struct rtc_wkalrm *tm)
 {
 	struct i2c_client *client = to_i2c_client(dev);
-	unsigned char buf[3];
 	int err;
 
 	dev_dbg(dev, "%s, sec=%d, min=%d hour=%d tm->enabled:%d\n",
 		__func__, tm->time.tm_sec, tm->time.tm_min, tm->time.tm_hour,
 		tm->enabled);
 
-	buf[0] = bin2bcd(tm->time.tm_sec);
-	buf[1] = bin2bcd(tm->time.tm_min);
-	buf[2] = bin2bcd(tm->time.tm_hour);
-
-	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_SCA, buf[0]);
+	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_SCA, bin2bcd(tm->time.tm_sec));
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_SCA\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_SCA\n");
 		return err;
 	}
 
-	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_MNA, buf[1]);
+	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_MNA, bin2bcd(tm->time.tm_min));
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_MNA\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_MNA\n");
 		return err;
 	}
 
-	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_HRA, buf[2]);
+	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_HRA, bin2bcd(tm->time.tm_hour));
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_HRA\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_HRA\n");
 		return err;
 	}
 
@@ -342,7 +346,7 @@ static long nct3018y_clkout_round_rate(struct clk_hw *hw, unsigned long rate,
 }
 
 static int nct3018y_clkout_set_rate(struct clk_hw *hw, unsigned long rate,
-				   unsigned long parent_rate)
+				    unsigned long parent_rate)
 {
 	struct nct3018y *nct3018y = clkout_hw_to_nct3018y(hw);
 	struct i2c_client *client = nct3018y->client;
@@ -418,15 +422,6 @@ static struct clk *nct3018y_clkout_register_clk(struct nct3018y *nct3018y)
 	struct device_node *node = client->dev.of_node;
 	struct clk *clk;
 	struct clk_init_data init;
-	int flags, err;
-
-	/* disable the clkout output */
-	flags = 0;
-	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_CLKO, flags);
-	if (err < 0) {
-		dev_err(&client->dev, "Unable to write oscillator status register\n");
-		return ERR_PTR(err);
-	}
 
 	init.name = "nct3018y-clkout";
 	init.ops = &nct3018y_clkout_ops;
@@ -448,7 +443,6 @@ static struct clk *nct3018y_clkout_register_clk(struct nct3018y *nct3018y)
 }
 #endif
 
-
 static const struct rtc_class_ops nct3018y_rtc_ops = {
 	.read_time	= nct3018y_rtc_read_time,
 	.set_time	= nct3018y_rtc_set_time,
@@ -464,10 +458,10 @@ static int nct3018y_probe(struct i2c_client *client,
 	struct nct3018y *nct3018y;
 	int err, flags;
 
-	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
-		dev_err(&client->dev, "%s: ENODEV\n", __func__);
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C |
+				     I2C_FUNC_SMBUS_BYTE |
+				     I2C_FUNC_SMBUS_BLOCK_DATA))
 		return -ENODEV;
-	}
 
 	nct3018y = devm_kzalloc(&client->dev, sizeof(struct nct3018y),
 				GFP_KERNEL);
@@ -480,22 +474,23 @@ static int nct3018y_probe(struct i2c_client *client,
 
 	flags = i2c_smbus_read_byte_data(client, NCT3018Y_REG_CTRL);
 	if (flags < 0) {
-		dev_err(&client->dev, "%s: read error\n", __func__);
+		dev_dbg(&client->dev, "%s: read error\n", __func__);
 		return flags;
-	} else if (flags & NCT3018Y_BIT_TWO)
+	} else if (flags & NCT3018Y_BIT_TWO) {
 		dev_dbg(&client->dev, "%s: NCT3018Y_BIT_TWO is set\n", __func__);
+	}
 
 	flags = NCT3018Y_BIT_TWO;
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_CTRL, flags);
 	if (err < 0) {
-		dev_err(&client->dev, "Unable to write NCT3018Y_REG_CTRL\n");
+		dev_dbg(&client->dev, "Unable to write NCT3018Y_REG_CTRL\n");
 		return err;
 	}
 
 	flags = 0;
 	err = i2c_smbus_write_byte_data(client, NCT3018Y_REG_ST, flags);
 	if (err < 0) {
-		dev_err(&client->dev, "%s: write error\n", __func__);
+		dev_dbg(&client->dev, "%s: write error\n", __func__);
 		return err;
 	}
 
@@ -509,11 +504,11 @@ static int nct3018y_probe(struct i2c_client *client,
 
 	if (client->irq > 0) {
 		err = devm_request_threaded_irq(&client->dev, client->irq,
-				NULL, nct3018y_irq,
-				IRQF_ONESHOT | IRQF_TRIGGER_FALLING,
-				"nct3018y", client);
+						NULL, nct3018y_irq,
+						IRQF_ONESHOT | IRQF_TRIGGER_FALLING,
+						"nct3018y", client);
 		if (err) {
-			dev_err(&client->dev, "unable to request IRQ %d\n", client->irq);
+			dev_dbg(&client->dev, "unable to request IRQ %d\n", client->irq);
 			return err;
 		}
 	}
@@ -531,7 +526,6 @@ static const struct i2c_device_id nct3018y_id[] = {
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, nct3018y_id);
-
 
 static const struct of_device_id nct3018y_of_match[] = {
 	{ .compatible = "nuvoton,nct3018y" },
@@ -551,5 +545,6 @@ static struct i2c_driver nct3018y_driver = {
 module_i2c_driver(nct3018y_driver);
 
 MODULE_AUTHOR("Medad CChien <ctcchien@nuvoton.com>");
+MODULE_AUTHOR("Mia Lin <mimi05633@gmail.com>");
 MODULE_DESCRIPTION("Nuvoton NCT3018Y RTC driver");
-MODULE_LICENSE("GPL v2");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Support Nuvoton NCT3018Y real time clock.

 - Fix warnings in rtc-nct3018y.c.
 - Reduce the number of error messages.
 - Add battery voltage level check.
 - Add functionality check.
 - Add maintainer.
 - Remove clock output disable.

Signed-off-by: Mia Lin <mimi05633@gmail.com>